### PR TITLE
Fix claims with multiple cuboids showing darker borders

### DIFF
--- a/ClaimRadar/ClaimRadar.cs
+++ b/ClaimRadar/ClaimRadar.cs
@@ -94,6 +94,7 @@ namespace ClaimRadar
                         capi.World.Player.Entity.Pos.DistanceTo(area.End.ToBlockPos().ToVec3d()) < 300.0)
                     {
                         claims.Add(claim);
+                        break;
                     }
                 } 
             }


### PR DESCRIPTION
When a claim has multiple cuboids the borders get darker. The more cuboids, the darker it becomes. With enough cuboids, a claim's border can become opaque to where you can't see through it.

This fixes that bug by only adding a claim to the list of claims to draw _once_ instead of for each cuboid.

Before fix:

![image](https://github.com/Skif97/ClaimsRadar/assets/332527/fd29b147-3d8d-4d1c-bf40-d9b8027f1390)

After fix:

![image](https://github.com/Skif97/ClaimsRadar/assets/332527/044ef86e-c6d9-445f-bfd5-c5e377df8975)
